### PR TITLE
docs:update framework docs zh-CN.md

### DIFF
--- a/src/Masa.Framework.Docs/wwwroot/pages/utils/extensions/expression/zh-CN.md
+++ b/src/Masa.Framework.Docs/wwwroot/pages/utils/extensions/expression/zh-CN.md
@@ -122,7 +122,7 @@
    }
    ```
 
-* Or\<T\>(bool isCompose, Expression\<Fun\c<T, bool\>\>? second): 当 `isCompose` 为 `false` 时，合并两个 `Expression` 表达式，条件是 **或者**
+* Or\<T\>(bool isCompose, Expression\<Func<T, bool\>\>? second): 当 `isCompose` 为 `true` 时，合并两个 `Expression` 表达式，条件是 **或者**
 
    :::: code-group
    ::: code-group-item Main 单元测试


### PR DESCRIPTION
# Description（描述）
Or示例的第二条示例中[当 isCompose 为 false 时，合并两个 Expression 表达式]应当为[当 isCompose 为 true 时，合并两个 Expression 表达式]
按代码中展示的逻辑应为[当 isCompose 为 true 时，合并两个 Expression 表达式] 且前面方法介绍中多了斜杠\

现将[当 isCompose 为 false 时，合并两个 Expression 表达式]改为[当 isCompose 为 true 时，合并两个 Expression 表达式] 且将方法介绍中多余的斜杠\去除
## Issue reference

#221 
